### PR TITLE
Error Catch Lastz

### DIFF
--- a/bin/assembly/match_contigs_to_probes.py
+++ b/bin/assembly/match_contigs_to_probes.py
@@ -245,6 +245,9 @@ def main():
                     matches[contig_name].add(uce_name)
                     orientation[uce_name].add(lz.strand2)
                     revmatches[uce_name].add(contig_name)
+        #error catch for lastz
+        else:	
+		    raise Exception("There is very likely an error with the Lastz on your machine. Make sure lastz exists in your path (use the 'which lastz' command).")
         # we need to check nodes for dupe matches to the same probes
         contigs_matching_mult_uces = check_contigs_for_dupes(matches)
         uces_matching_mult_contigs = check_probes_for_dupes(revmatches)


### PR DESCRIPTION
The change alerts the user if lastz is not correctly installed or is broken on his or her computer. Previously, the code ran an operation checking the status of lztstderr, but didn't alert the user if an issue arose. Now, an else statement raises an exception which alerts the user if lastz is not working.
