### PR TITLE
Update regexen that extract contig names

### DIFF
--- a/bin/assembly/get_fastas_from_match_counts.py
+++ b/bin/assembly/get_fastas_from_match_counts.py
@@ -108,7 +108,7 @@ def get_nodes_for_uces(c, organism, uces, extend=False, notstrict=False):
     missing = []
     for node in rows:
         if node[0] is not None:
-            match = re.search('^(node_\d+|comp\d+_c\d+_seq\d+)\(([+-])\)', node[0])
+            match = re.search('^(node_\d+|comp\d+_c\d+_seq\d+|c\d+_g\d+_i\d+)\(([+-])\)', node[0], flags=re.I)
             node_dict[match.groups()[0]] = (node[1], match.groups()[1])
         elif notstrict:
             missing.append(node[1])
@@ -142,7 +142,7 @@ def find_file(contigs, name):
 
 def get_contig_name(header):
     """parse the contig name from the header of either velvet/trinity assembled contigs"""
-    match = re.search("^(Node_\d+|NODE_\d+|comp\d+_c\d+_seq\d+).*", header)
+    match = re.search("^(node_\d+|comp\d+_c\d+_seq\d+|c\d+_g\d+_i\d+).*", header, flags=re.I)
     return match.groups()[0]
 
 

--- a/bin/assembly/match_contigs_to_probes.py
+++ b/bin/assembly/match_contigs_to_probes.py
@@ -223,7 +223,7 @@ def pretty_log_output(log, critter, matches, contigs, pd, mc, uce_dupe_uces):
 
 def get_contig_name(header):
     """parse the contig name from the header of either velvet/trinity assembled contigs"""
-    match = re.search("^(Node_\d+|NODE_\d+|comp\d+_c\d+_seq\d+|c\d+_g\d+_i\d+).*", header)
+    match = re.search("^(node_\d+|comp\d+_c\d+_seq\d+|c\d+_g\d+_i\d+).*", header, flags=re.I)
     return match.groups()[0]
 
 


### PR DESCRIPTION
Commit 98ef79d4 changed the extraction regex in one file, but not another. This commit updates the remaining regexes.

Ideally the regex would be stored somewhere in the phyluce module, and updating it in one place would ensure that the same regex was used everywhere.