### PR TITLE
change outfile extension to reflect output format

### DIFF
--- a/bin/align/add_missing_data_designators.py
+++ b/bin/align/add_missing_data_designators.py
@@ -175,7 +175,7 @@ def add_designators(work):
     aln = AlignIO.read(file, input_format)
     new_align = add_gaps_to_align(aln, organisms, check_missing, missing, verbatim, min_taxa)
     if new_align is not None:
-        outf = os.path.join(output, os.path.basename(file))
+        outf = os.path.join(output, os.path.splitext(os.path.basename(file))[0] + "." + output_format)
         AlignIO.write(new_align, open(outf, 'w'), output_format)
         return None
     else:


### PR DESCRIPTION
when input format and output format of alignments are different, the current code uses the wrong extension in the output files.